### PR TITLE
Update resources to frc-docs

### DIFF
--- a/source/ch06b_PrepLinuxRobot.rst
+++ b/source/ch06b_PrepLinuxRobot.rst
@@ -63,7 +63,7 @@ Next, install the required software packages using the following commands:
  - CAN Tools ``sudo apt-get install can-utils``
  - Git ``sudo apt-get install git``
  - cmake (for build support) ``sudo apt-get install cmake``
- - libsdl12 (for gamepad support) ``sudo ap-get install libsdl2-dev``
+ - libsdl12 (for gamepad support) ``sudo apt-get install libsdl2-dev``
 
 
 With the necessary software installed, clone the example repository into the user directory.  This example is a basic C++ project that includes all necessary Phoenix libraries and will be used to validate the hardware and software setup.

--- a/source/ch23_AddResource.rst
+++ b/source/ch23_AddResource.rst
@@ -13,20 +13,20 @@ https://github.com/CrossTheRoadElec/Phoenix-Examples-LabVIEW
 
 Phoenix C++/Java API Documentation
 --------------------------------------------------------------
-http://www.ctr-electronics.com/downloads/api/java/html/index.html
-http://www.ctr-electronics.com/downloads/api/cpp/html/index.html
+https://www.ctr-electronics.com/downloads/api/java/html/index.html
+https://www.ctr-electronics.com/downloads/api/cpp/html/index.html
 
 FRC Screensteps
 --------------------------------------------------------------
 Core documentation for the base FRC control system.
-http://wpilib.screenstepslive.com/s/currentCS
+https://docs.wpilib.org
 
 Power Distribution Panel (PDP)
 --------------------------------------------------------------
-http://wpilib.screenstepslive.com/s/currentCS/m/cpp/l/599692-power-distribution-panel
-http://wpilib.screenstepslive.com/s/currentCS/m/java/l/599694-using-the-can-subsystem-with-the-roborio
+https://docs.wpilib.org/en/latest/docs/software/can-devices/power-distribution-panel.html
+https://docs.wpilib.org/en/latest/docs/software/can-devices/using-can-devices.html
 
 Pneumatics Control Module (PCM)
 --------------------------------------------------------------
-http://wpilib.screenstepslive.com/s/currentCS/m/java/l/219351-pneumatics-control-module
-http://wpilib.screenstepslive.com/s/currentCS/m/cpp/l/241865-operating-a-compressor-for-pneumatics
+https://docs.wpilib.org/en/latest/docs/software/can-devices/pneumatics-control-module.html
+https://docs.wpilib.org/en/latest/docs/hardware/hardware-basics/wiring-pneumatics.html


### PR DESCRIPTION
# Pull Request Template

## Description of change

Change links from screensteps to docs.wpilib.org. Use https.

## Why this should be added

WPILib has changed documentation from screensteps to docs.wpilib.org. The old links no longer work

## Test Procedure

click links

## Test Results

See documentation

## Related Pull Requests/Issues

[Add your text here]
