### PR TITLE
Replace screensteps with frc-docs

### DIFF
--- a/source/ch05a_CppJava.rst
+++ b/source/ch05a_CppJava.rst
@@ -7,7 +7,7 @@ FRC C++/Java – Create a Project
 
 Next we will create a new robot project in vscode and create a Talon SRX.  The goal is compile the project only, so hardware is not needed.
 
-Follow the WPI Screensteps instructions on reaching the create new project.  Typically, you can use CNTRL+SHIFT+P to open the VS text bar, and type create to reach the WPI command.
+Follow the WPI frc-docs instructions on reaching the create new project.  Typically, you can use CNTRL+SHIFT+P to open the VS text bar, and type create to reach the WPI command.
 
 .. image:: img/verify-1.png
 

--- a/source/ch20_FAQ.rst
+++ b/source/ch20_FAQ.rst
@@ -115,7 +115,7 @@ This is typical if the robot is not enabled OR if the robot application did not 
 
 Make sure the robot is truly enabled by looking at the Driver Station.
 
-Instructions for creating a Solenoid, DoubleSolenoid or Compressor object in LabVIEW, C++, and Java can be found at http://wpilib.screenstepslive.com, (search for keyword “PCM”). Creating a single object of any pneumatics related type is sufficient for enabling the PCM (and therefore enabling compressor closed-loop).
+Instructions for creating a Solenoid, DoubleSolenoid or Compressor object in LabVIEW, C++, and Java can be found at https://docs.wpilib.org, (search for keyword “PCM”). Creating a single object of any pneumatics related type is sufficient for enabling the PCM (and therefore enabling compressor closed-loop).
 
 .. note:: In order to create a software object for Solenoid or Compressor, typically the caller may specify the CAN Device ID (not specifying it typically defaults to selecting Device ID zero). This value must match what is specified in Phoenix Tuner. For more information see :ref:`can-bringup-setIDs`.
 

--- a/source/ch23_AddResource.rst
+++ b/source/ch23_AddResource.rst
@@ -16,7 +16,7 @@ Phoenix C++/Java API Documentation
 https://www.ctr-electronics.com/downloads/api/java/html/index.html
 https://www.ctr-electronics.com/downloads/api/cpp/html/index.html
 
-FRC Screensteps
+FRC WPILib Docs
 --------------------------------------------------------------
 Core documentation for the base FRC control system.
 https://docs.wpilib.org


### PR DESCRIPTION
# Pull Request Template

## Description of change

Change links from screensteps to docs.wpilib.org.

## Why this should be added

WPILib has changed documentation from screensteps to docs.wpilib.org. The old links no longer work

## Test Procedure

click links

## Test Results

See documentation

## Related Pull Requests/Issues

[Add your text here]
