### PR TITLE
Fix typo.

### DIFF
--- a/source/ch15_WPIDrive.rst
+++ b/source/ch15_WPIDrive.rst
@@ -4,7 +4,7 @@ WPI/NI Software Integration
 ===========================
 
 The stock software frameworks in the FRC control system has several features used by teams.
-To leverage these features, the C++ /Java Phoenix API has two additional classes:
+To leverage these features, the C++ /Java Phoenix API has three additional classes:
 
 - WPI_TalonFX
 - WPI_TalonSRX


### PR DESCRIPTION
This pull request fixes a typo in the documentation. [Here](https://github.com/CrossTheRoadElec/Phoenix-Documentation/commit/967cd600cbe97c829118b821e41e86573e60773f#diff-5cf6cc2bcc29db0ef38375030bcce28eR9), `WPI_TalonFX` was added to the list of classes, without changing "two"