### PR TITLE
PR: Issue 1360

### DIFF
--- a/source/ch06b_PrepLinuxRobot.rst
+++ b/source/ch06b_PrepLinuxRobot.rst
@@ -126,6 +126,40 @@ You should see a constant stream of messages similar to this:
 .. image:: img/candump.png
 
 
+.. _SocketCan:
+
+Running the SocketCan Example
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Build the example with ``./build.sh``. 
+
+Then run the example with ``./bin/example``.
+
+You're now running Phoenix on your Linux device. Confirm there are no error messages being sent to console output.
+
+.. note:: You may see error messages if your CAN devices are not yet configured and firmware updated.  Follow the :ref:`Bring Up: CAN<ch08_BringUpCAN>` section to setup your CAN devices.
+
+.. warning:: If your CTRE CAN devices were previously used with a roboRIO it is likely they are FRC locked and will not enable without a roboRIO on the CAN bus.
+	See :ref:`Confirm FRC Unlock<frc-unlock>` for instructions to confirm FRC unlock.
+
+You can stop your Program with ``Ctrl+z``.
+
+Modifying the SocketCan Example
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+To modify the example  
+Open the file explorer and navigate to the Phoenix-Linux-SocketCAN-Example folder.
+
+.. image:: img/opening.png
+
+
+The example is a simple program, so all of the code is contained within example.cpp.  Edit this file to modify the program.
+
+.. image:: img/inside.png
+
+After modifying the file click the ``Save`` button in the top right corner then Go back to :ref:`Running the SocketCAN Example<SocketCan>` to run your modified example.
+
+.. image:: img/editor.png
+
+
 How to setup Phoenix Tuner?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -179,40 +213,6 @@ Confirm the bottom status bar is green and healthy, and server version is presen
 If there are CAN device present they will appear in the "CAN Devices" tab.  However, it is possible that devices will appear to be missing - this will be resolved in "Bring Up: CAN Bus".
 
 .. image:: img/tuner-6.png
-
-
-.. _SocketCan:
-
-Running the SocketCan Example
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-Build the example with ``./build.sh``. 
-
-Then run the example with ``./bin/example``.
-
-You're now running Phoenix on your Linux device. Confirm there are no error messages being sent to console output.
-
-.. note:: You may see error messages if your CAN devices are not yet configured and firmware updated.  Follow the :ref:`Bring Up: CAN<ch08_BringUpCAN>` section to setup your CAN devices.
-
-.. warning:: If your CTRE CAN devices were previously used with a roboRIO it is likely they are FRC locked and will not enable without a roboRIO on the CAN bus.
-	See :ref:`Confirm FRC Unlock<frc-unlock>` for instructions to confirm FRC unlock.
-
-You can stop your Program with ``Ctrl+z``.
-
-Modifying the SocketCan Example
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-To modify the example  
-Open the file explorer and navigate to the Phoenix-Linux-SocketCAN-Example folder.
-
-.. image:: img/opening.png
-
-
-The example is a simple program, so all of the code is contained within example.cpp.  Edit this file to modify the program.
-
-.. image:: img/inside.png
-
-After modifying the file click the ``Save`` button in the top right corner then Go back to :ref:`Running the SocketCAN Example<SocketCan>` to run your modified example.
-
-.. image:: img/editor.png
 
 
 

--- a/source/ch06b_PrepLinuxRobot.rst
+++ b/source/ch06b_PrepLinuxRobot.rst
@@ -178,6 +178,8 @@ Enter the IP Address or Name of the Linux Robot Controller into Phoenix tuner.
 
 
 Your program runs the diagnostics server, so you do not need to install the diagnostics server through Phoenix Tuner.
+You can disable the diagnostics server in your program by adding ``c_SetPhoenixDiagnosticsStartTime(-1);`` to the start
+of your main method. The line is commented out in the example program.
 
 .. raw:: html
 

--- a/source/ch06b_PrepLinuxRobot.rst
+++ b/source/ch06b_PrepLinuxRobot.rst
@@ -165,6 +165,8 @@ How to setup Phoenix Tuner?
 
 With the CAN network up and running, Phoenix Tuner can be used with the Linux Robot Controller in the same manner as the roboRIO.
 
+.. note:: SSH must be enabled on the Linux Robot Controller to perform a field upgrade or modify a device's configuration using Phoenix Tuner.
+
 Connect both the Linux Robot Controller and Windows machine to the same network via WiFi or and ethernet connection.
 
 Enter the IP Address or Name of the Linux Robot Controller into Phoenix tuner.

--- a/source/ch06b_PrepLinuxRobot.rst
+++ b/source/ch06b_PrepLinuxRobot.rst
@@ -177,7 +177,9 @@ Enter the IP Address or Name of the Linux Robot Controller into Phoenix tuner.
 .. |_Linux_IP_Image_| image:: img/LinuxWlan.png
 
 
-Press the Install button.
+Your program runs the diagnostics server in the background, so you do not need to install the diagnostics server through Phoenix Tuner.
+
+~~Press the Install button.
 
 .. image:: img/tuner-4.png
 
@@ -197,7 +199,7 @@ Enter your username and password when prompted.
 
 Tuner will then install and start the diagnostics server on the device.
 
-The diagnostics server is now installed and running on your device.
+The diagnostics server is now installed and running on your device.~~
 
 
 

--- a/source/ch06b_PrepLinuxRobot.rst
+++ b/source/ch06b_PrepLinuxRobot.rst
@@ -177,9 +177,13 @@ Enter the IP Address or Name of the Linux Robot Controller into Phoenix tuner.
 .. |_Linux_IP_Image_| image:: img/LinuxWlan.png
 
 
-Your program runs the diagnostics server in the background, so you do not need to install the diagnostics server through Phoenix Tuner.
+Your program runs the diagnostics server, so you do not need to install the diagnostics server through Phoenix Tuner.
 
-~~Press the Install button.
+.. raw:: html
+
+	<strike>
+
+Press the Install button.
 
 .. image:: img/tuner-4.png
 
@@ -199,7 +203,11 @@ Enter your username and password when prompted.
 
 Tuner will then install and start the diagnostics server on the device.
 
-The diagnostics server is now installed and running on your device.~~
+The diagnostics server is now installed and running on your device.
+
+.. raw:: html
+
+	</strike>
 
 
 

--- a/source/ch06b_PrepLinuxRobot.rst
+++ b/source/ch06b_PrepLinuxRobot.rst
@@ -179,13 +179,24 @@ Enter the IP Address or Name of the Linux Robot Controller into Phoenix tuner.
 .. |_Linux_IP_Image_| image:: img/LinuxWlan.png
 
 
-Your program runs the diagnostics server, so you should not install the diagnostics server through Phoenix Tuner.
+Setting up the Phoenix Diagnostics Server
+-----------------------------------------
+
+The Phoenix Diagnostics Server is an HTTP server that communicates with the Phoenix Tuner. There are two versions of the server:
+a standalone version installed through Phoenix Tuner (legacy), and a version built into your user program (latest). Only one version of
+the diagnostics server may be running at any given time. We recommend you run the diagnostics server through your user program.
+
 You can disable the diagnostics server in your program by adding ``c_SetPhoenixDiagnosticsStartTime(-1);`` to the start
 of your main method. The line is commented out in the example program.
 
+.. warning:: The instructions below are available for legacy support. We recommend you instead run the Phoenix Diagnostics Server in your user program.
+
+.. warning:: The legacy instructions below currently do not work. See: https://github.com/CrossTheRoadElec/Phoenix-Linux-SocketCAN-Example/issues/15
 .. raw:: html
 
 	<strike>
+
+To install the standalone diagnostics server:
 
 Press the Install button.
 

--- a/source/ch06b_PrepLinuxRobot.rst
+++ b/source/ch06b_PrepLinuxRobot.rst
@@ -177,7 +177,7 @@ Enter the IP Address or Name of the Linux Robot Controller into Phoenix tuner.
 .. |_Linux_IP_Image_| image:: img/LinuxWlan.png
 
 
-Your program runs the diagnostics server, so you do not need to install the diagnostics server through Phoenix Tuner.
+Your program runs the diagnostics server, so you should not install the diagnostics server through Phoenix Tuner.
 You can disable the diagnostics server in your program by adding ``c_SetPhoenixDiagnosticsStartTime(-1);`` to the start
 of your main method. The line is commented out in the example program.
 


### PR DESCRIPTION
This branch updates the documentation to
1. no longer have the user install the Phoenix Diagnostics Server through Phoenix Tuner (https://github.com/CrossTheRoadElec/Phoenix-Linux-SocketCAN-Example/issues/15)
2. have the user run their SocketCAN program with the diagnostics server built in prior to starting Phoenix Tuner