### PR TITLE
Add CI, Fix links, Disable warnings as errors

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,62 @@
+name: CI
+
+on: [pull_request, push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+      with:
+        python-version: 3.9
+    - name: Install Python Dependencies
+      run: |
+        pip install -r requirements.txt
+    - name: Install LaTeX
+      run: |
+        sudo apt-get update
+        sudo apt install -y texlive-latex-recommended texlive-fonts-recommended texlive-latex-extra latexmk texlive-lang-greek texlive-luatex texlive-xetex texlive-fonts-extra dvipng librsvg2-bin
+    - name: Build HTML
+      run: |
+        make html
+    - name: Archive HTML
+      uses: actions/upload-artifact@v2
+      with:
+        name: phoenix-html
+        path: build/html/
+    - name: Build PDF
+      run: |
+        make latexpdf
+    - name: Archive PDF
+      uses: actions/upload-artifact@v2
+      with:
+        name: phoenix-pdf
+        path: build/latex/phoenix.pdf
+  check-links:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Checkout dev
+      run: |
+        git fetch origin dev --depth=1
+    - uses: actions/setup-python@v2
+      with:
+        python-version: 3.9
+    - name: Install Dependencies
+      run: |
+        pip install -r requirements.txt
+    - name: Check Links
+      run: |
+        make linkcheck
+  check-spelling:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: misspell
+        uses: reviewdog/action-misspell@v1
+        with:
+          locale: "US"
+          reporter: "github-check"
+          exclude: |
+            ./Legacy/**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Table of Contents
 - [Pull Requests](#pull-requests)
 
 ## Reporting Bugs
-Submitting bugs relevant to the API will typically be done in the [Phoenix-FRC-Lib](https://github.com/CrossTheRoadElec/Phoenix-frc-lib) repository. Use a descriptive title. Use the following format:
+Submitting bugs relevant to the API will typically be done in the [Phoenix-Releases](https://github.com/CrossTheRoadElec/Phoenix-Releases) repository. Use a descriptive title. Use the following format:
 ```
 Expected behavior, link to documentation referencing expected behavior beneficial.
 Observed behavior. Screenshots of self test strongly recommended.
@@ -18,7 +18,7 @@ Good example:
 Title: Motor output incorrect when Current Limit is Enabled
 Expected behavior: Motor output follows driven percent output or less when current limit is enabled (Section 9.3 of Talon SRX Software Reference Manual)
 Observed behavior: Motor output "sticks" to previous value or oscillates between driven percent output and off when current limit is enabled
-Procedure: Factory-Reset Talon SRX -> Configure Peak Limit to 5 amps -> Configure Continous Current to 5 amps -> Drive CIM Motor to full speed -> Observed Behavior
+Procedure: Factory-Reset Talon SRX -> Configure Peak Limit to 5 amps -> Configure Continuous Current to 5 amps -> Drive CIM Motor to full speed -> Observed Behavior
 Versions: Phoenix 5.3.1.0, Talon SRX Firmware 3.8, RoboRIO Image v17, WPILib Update 2018.4.1, Java
 ```
 ## Requesting a Feature

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 #
 # You can set these variables from the command line.
 
-SPHINXOPTS    = -W --keep-going
+SPHINXOPTS    = --keep-going
 SPHINXBUILD   = sphinx-build
 SOURCEDIR     = source
 BUILDDIR      = build

--- a/make.bat
+++ b/make.bat
@@ -9,7 +9,7 @@ if "%SPHINXBUILD%" == "" (
 )
 set SOURCEDIR=source
 set BUILDDIR=build
-set SPHINXOPTS=-W --keep-going
+set SPHINXOPTS=--keep-going
 set LINTER=doc8
 set LINTEROPTS=--ignore D001 --ignore D004
 set CONFEXCLUDE=--exclude-file source/conf.py

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -3,7 +3,7 @@ version: 2
 sphinx:
   builder: html
   configuration: source/conf.py
-  fail_on_warning: true
+  fail_on_warning: false
 
 build:
   os: ubuntu-20.04

--- a/source/blog/blog-kickoff-2019.rst
+++ b/source/blog/blog-kickoff-2019.rst
@@ -28,7 +28,7 @@ New features below
 * Phoenix Tuner can be used to factory default config settings (as well as API).
 * Phoenix Tuner can field-upgrade all same-model devices with one click.
 * Phoenix Tuner can be used to perform Pigeon IMU temperature calibration.
-* New config routines to simplify management of persistent settings: configFactoryDefault and `configAllSettings <https://github.com/CrossTheRoadElec/Phoenix-Examples-Languages/tree/master/Java/Config%20All>`_
+* New config routines to simplify management of persistent settings: configFactoryDefault and `configAllSettings <https://github.com/CrossTheRoadElec/Phoenix-Examples-Languages/tree/master/Java%20General/Config%20All>`_
 * Compatibility with WPI distributed Visual Studio Code interface and GradleRIO build system.
 * Maven hosted API provides an alternative to using the Phoenix installer to get API binaries (however the offline install is highly recommended).
 * No more FRC versus nonFRC firmware, see "FRC Lock" features for explanation.

--- a/source/blog/blog-week1.rst
+++ b/source/blog/blog-week1.rst
@@ -45,7 +45,7 @@ So as a reminder, teams should ensure that their motor controllers are up to dat
 Phoenix on other platforms?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Some teams are already aware that *Phoenix isn't just a library targeted for the roboRIO*.
-For those of you perusing our `maven site <http://devsite.ctr-electronics.com/maven/release/com/ctre/phoenix>`_ you may have noticed *several Linux binaries*.
+For those of you perusing our maven site you may have noticed *several Linux binaries*.
 These have been used for leveraging Talons/Victors/CANifiers/Pigeon on third party hardware such as:
 
 - Raspberry PI + SocketCAN interface

--- a/source/blog/blog-week4.rst
+++ b/source/blog/blog-week4.rst
@@ -14,7 +14,7 @@ In this release the following components were updated:
 - New Phoenix API v15.3
 - New Firmware for Talon SRX (4.15), Victor SPX (4.15) and Pigeon IMU (4.13).
 
-A breakdown of the changes are below, but due to the variety of improvements and how these components interact, we **strongly recommend collectively updating all three components** before `Stop Build Day <https://www.firstinspires.org/robotics/frc/season-calendar/stop-build-day>`_.
+A breakdown of the changes are below, but due to the variety of improvements and how these components interact, we **strongly recommend collectively updating all three components** before Stop Build Day.
 
 How To download
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -57,7 +57,7 @@ Some teams are beginning to move into the "tuning" phase of their mechanisms, so
 Phoenix Libraries cleared on roboRIO reboot 
 -----------------------------------------------------------------
 We received a couple reports where the roboRIO appears to be *losing Phoenix libraries after a power cycle*.
-The root-cause was determined to be **teams accidently using HERO LifeBoat** to install 2018 libraries in a location that prevents the 2019 libraries from loading correctly.
+The root-cause was determined to be **teams accidentally using HERO LifeBoat** to install 2018 libraries in a location that prevents the 2019 libraries from loading correctly.
 Details on this can be found at https://github.com/CrossTheRoadElec/Phoenix-Releases/issues/1
 
 **To solve this completely** we made two changes:

--- a/source/blog/blog-week6.rst
+++ b/source/blog/blog-week6.rst
@@ -45,7 +45,7 @@ This means that the sharp "corner" points typical of the simpler trapezoidal met
 
 .. image:: ../img/blog-week6-2.png
 
-.. note:: Image source: http://www.ni.com/product-documentation/4824/en/
+.. note:: Image source: https://electronics.stackexchange.com/questions/38573/smooth-a-motor-movement
 
 Due to the successful and widespread use of this control mode, we've enhanced it to allow for true S-Curve profiling.
 

--- a/source/ch06_PrepRobot.rst
+++ b/source/ch06_PrepRobot.rst
@@ -28,7 +28,7 @@ So we have **opted to deploy our binaries directly from Phoenix Tuner** to ensur
 
 As a result starting in 2022, LabVIEW users must install Phoenix API libraries into their roboRIO (after roboRIO is imaged).  Afterwards deploy your LabVIEW application as you would normally.
 
-.. tip:: Remember to specify the **Team Number** or **Address** of the roboRIO under Diagnostic Server Adress.  We recommend using the USB cable and selecting "172.22.11.2" to avoid networking issues.
+.. tip:: Remember to specify the **Team Number** or **Address** of the roboRIO under Diagnostic Server Address.  We recommend using the USB cable and selecting "172.22.11.2" to avoid networking issues.
 
 .. image:: img/tuner-deploy-labview.png
 

--- a/source/ch12b_BringUpCANdle.rst
+++ b/source/ch12b_BringUpCANdle.rst
@@ -28,4 +28,4 @@ There is a basic example for using CAndle here:
 `C++ <https://github.com/CrossTheRoadElec/Phoenix-Examples-Languages/tree/master/C%2B%2B%20General/CANdle>`_ | `Java <https://github.com/CrossTheRoadElec/Phoenix-Examples-Languages/tree/master/Java%20General/CANdle>`_
 
 An advanced example using multiple animations can be found here:  
-`Java <https://github.com/CrossTheRoadElec/Phoenix-Examples-Languages/tree/CANdle-MultiAnimations/Java%20General/CANdle%20MultiAnimation>`_
+`Java <https://github.com/CrossTheRoadElec/Phoenix-Examples-Languages/tree/master/Java%20General/CANdle%20MultiAnimation>`_

--- a/source/ch16_ClosedLoop.rst
+++ b/source/ch16_ClosedLoop.rst
@@ -583,7 +583,7 @@ Be sure that the first point has zeroPos set to true if you wish to zero the pos
 
 Java example:
 
-.. sphynx note: the comments are not arranged perfecty due to tabs=8 on RTD while VSCode uses tabs=4
+.. sphynx note: the comments are not arranged perfectly due to tabs=8 on RTD while VSCode uses tabs=4
 
 .. code-block:: java
 
@@ -639,7 +639,7 @@ This is called Motion Profile Arc control mode, and utilizes everything that's b
 
 Below is a guide on how to get Motion Profiling Arc up and running, using the new Buffered Stream API.
 
-.. note:: This is also an example that is available on `our examples repo <https://github.com/CrossTheRoadElec/Phoenix-Examples-Languages/tree/master/Java/MotionProfileArc_Simple>`_
+.. note:: This is also an example that is available on `our examples repo <https://github.com/CrossTheRoadElec/Phoenix-Examples-Languages/tree/master/Java%20General/MotionProfileArc_Simple>`_
 
 
 .. note:: The steps for using motion profile arc are very similar and reference the steps for creating a normal motion profile. Read them first

--- a/source/conf.py
+++ b/source/conf.py
@@ -78,7 +78,7 @@ source_suffix = '.rst'
 # The master toctree document.
 master_doc = 'index'
 
-# Only one langauge supported, no URL prefix
+# Only one language supported, no URL prefix
 # This is only needed when deploying a non-RTD server
 on_rtd = os.environ.get('READTHEDOCS') == 'True'
 
@@ -145,14 +145,27 @@ htmlhelp_basename = 'Phoenixdoc'
 
 # -- Options for LaTeX output ------------------------------------------------
 
-# Grouping the document tree into LaTeX files. List of tuples
-# (source start file, target name, title,
-#  author, documentclass [howto, manual, or own class]).
-latex_documents = [
-    (master_doc, 'Phoenix.tex', 'Phoenix Documentation',
-     'CTRE', 'manual'),
-]
+latex_engine = "xelatex"
 
+# Disable xindy support
+# See: https://github.com/readthedocs/readthedocs.org/issues/5476
+latex_use_xindy = False
+
+latex_elements = {
+    "fontpkg": r"""
+	\setmainfont{DejaVu Serif}
+	\setsansfont{DejaVu Sans}
+	\setmonofont{DejaVu Sans Mono}""",
+    "preamble": r"""
+	\usepackage[titles]{tocloft}
+	\cftsetpnumwidth {1.25cm}\cftsetrmarg{1.5cm}
+	\setlength{\cftchapnumwidth}{0.75cm}
+	\setlength{\cftsecindent}{\cftchapnumwidth}
+	\setlength{\cftsecnumwidth}{1.25cm}
+	""",
+    "fncychap": r"\usepackage[Bjornstrup]{fncychap}",
+    "printindex": r"\footnotesize\raggedright\printindex",
+}
 
 # -- Options for manual page output ------------------------------------------
 
@@ -177,3 +190,23 @@ texinfo_documents = [
 
 
 # -- Extension configuration -------------------------------------------------
+
+# Disable checking anchors for linkcheck builder
+linkcheck_anchors = False
+
+# Set various linkcheck timeouts
+linkcheck_timeout = 30
+linkcheck_retries = 3
+linkcheck_workers = 1
+
+# Specify a standard user agent, as Sphinx default is blocked on some sites
+user_agent = "Mozilla/5.0 (X11; Linux x86_64; rv:25.0) Gecko/20100101 Firefox/25.0"
+
+# Autosection labels prefix document path and filename
+# Helps handle label collisions throughout the documentation
+autosectionlabel_prefix_document = True
+
+# Linkcheck exclusions
+linkcheck_ignore = [
+    r".*canable.io.*",
+]


### PR DESCRIPTION
This PR:
- Fixes the various amount of broken links and removed dead unapplicable links
- Adds CI build, link and spelling checks
- Refactors the PDF generation slightly to better build on Windows
- Removes warning on error until I can fix them