### PR TITLE
PR: Mention CANivore in Linux Robot Bring-up

### DIFF
--- a/source/ch06b_PrepLinuxRobot.rst
+++ b/source/ch06b_PrepLinuxRobot.rst
@@ -20,7 +20,9 @@ Below are the currently supported Linux hardware platforms.  An additional Socke
 
 It is possible to use other hardware platforms, however hardware and software setup may be different than this documentation.
 
-.. note:: CTRE currently recommends the CANable for use as a SocketCAN device.  More information can be found here: https://canable.io/
+.. note:: CTRE currently recommends the CANable for use as a generic SocketCAN device.  More information can be found here: https://canable.io/
+
+.. note:: CTRE now supports using the :ref:`CANivore <ch08a_BringUpCANivore>` as a SocketCAN device with Phoenix CAN FD devices on supported Linux platforms.
 
 How to prepare Hardware?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/ch06b_PrepLinuxRobot.rst
+++ b/source/ch06b_PrepLinuxRobot.rst
@@ -20,9 +20,9 @@ Below are the currently supported Linux hardware platforms.  An additional Socke
 
 It is possible to use other hardware platforms, however hardware and software setup may be different than this documentation.
 
-.. note:: CTRE currently recommends the CANable for use as a generic SocketCAN device.  More information can be found here: https://canable.io/
-
 .. note:: CTRE now supports using the :ref:`CANivore <ch08a_BringUpCANivore>` as a SocketCAN device with Phoenix CAN FD devices on supported Linux platforms.
+
+.. note:: CTRE currently recommends the CANable for use as a generic CAN 2.0 SocketCAN device.  More information can be found here: https://canable.io/
 
 How to prepare Hardware?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/ch08_BringUpCAN.rst
+++ b/source/ch08_BringUpCAN.rst
@@ -169,7 +169,7 @@ Moving forward, the first number of the version will represent the season (next 
 .. image:: img/bring-6.png
 
 Select the CRF under the Field-upgrade section then press Update Device.
-The CRFs are available in multiple places, and likely are already on your PC. See section :ref:`Device Firmware Files (crf)`.
+The CRFs are available in multiple places, and likely are already on your PC. See section :ref:`Device Firmware Files (crf) <ch05_PrepWorkstation:Device Firmware Files (crf)>`.
 
 If there are multiple devices of same type (multiple Talon SRXs for example), you may check Update all devices.  This will automatically iterate through all the devices of the same type, and update them.  If a device field-upgrade fails, then the operation will complete.  Confirm Firmware Version column in the device list after field-upgrade.
 

--- a/source/ch08a_BringUpCANivore.rst
+++ b/source/ch08a_BringUpCANivore.rst
@@ -56,7 +56,7 @@ Field upgrade CANivores
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 In the CANivores tab of Phoenix Tuner, select the CANivore you wish to update.
 Select the CRF under the Field-upgrade section then press Update Device.
-The CRFs are available in multiple places, and likely are already on your PC. See section :ref:`Device Firmware Files (crf)`.
+The CRFs are available in multiple places, and likely are already on your PC. See section :ref:`Device Firmware Files (crf) <ch05_PrepWorkstation:Device Firmware Files (crf)>`.
 
 If you wish to update all attached CANivores, check Update all CANivores. If a CANivore field-upgrade fails, then the operation will complete.
 Confirm Firmware Version column in the device list after field-upgrade.


### PR DESCRIPTION
We now support the CANivore on Linux desktop, NVidia Jetson, and Raspberry Pi, so this branch adds a note to the "Prepare Linux Robot Controller" page mentioning that support.

This branch also fixes some links to the Device Firmware Files section.